### PR TITLE
bpo-38841: Skip asyncio test_create_datagram_endpoint_existing_sock_u…

### DIFF
--- a/Lib/test/test_asyncio/test_base_events.py
+++ b/Lib/test/test_asyncio/test_base_events.py
@@ -1700,7 +1700,7 @@ class BaseEventLoopWithSelectorTests(test_utils.TestCase):
         self.loop.run_until_complete(protocol.done)
         self.assertEqual('CLOSED', protocol.state)
 
-    @unittest.skipUnless(hasattr(socket, 'AF_UNIX'), 'No UNIX Sockets')
+    @support.skip_unless_bind_unix_socket
     def test_create_datagram_endpoint_existing_sock_unix(self):
         with test_utils.unix_socket_path() as path:
             sock = socket.socket(socket.AF_UNIX, type=socket.SOCK_DGRAM)

--- a/Misc/NEWS.d/next/Tests/2019-11-20-16-08-19.bpo-38841.5F5Lbw.rst
+++ b/Misc/NEWS.d/next/Tests/2019-11-20-16-08-19.bpo-38841.5F5Lbw.rst
@@ -1,0 +1,2 @@
+Skip asyncio test_create_datagram_endpoint_existing_sock_unix on platforms
+lacking a functional bind() for named unix domain sockets.


### PR DESCRIPTION
…nix (GH-17294)

on platforms lacking a functional bind() for named unix domain sockets



https://bugs.python.org/issue38841



Automerge-Triggered-By: @asvetlov

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
