### PR TITLE
bpo-38881: choices() raises ValueError when all weights are zero (GH-…

### DIFF
--- a/Doc/library/random.rst
+++ b/Doc/library/random.rst
@@ -165,8 +165,9 @@ Functions for sequences
 
    The *weights* or *cum_weights* can use any numeric type that interoperates
    with the :class:`float` values returned by :func:`random` (that includes
-   integers, floats, and fractions but excludes decimals).  Weights are
-   assumed to be non-negative.
+   integers, floats, and fractions but excludes decimals).  Behavior is
+   undefined if any weight is negative.  A :exc:`ValueError` is raised if all
+   weights are zero.
 
    For a given seed, the :func:`choices` function with equal weighting
    typically produces a different sequence than repeated calls to
@@ -176,6 +177,9 @@ Functions for sequences
    to avoid small biases from round-off error.
 
    .. versionadded:: 3.6
+
+   .. versionchanged:: 3.9
+      Raises a :exc:`ValueError` if all weights are zero.
 
 
 .. function:: shuffle(x[, random])

--- a/Lib/random.py
+++ b/Lib/random.py
@@ -413,8 +413,10 @@ class Random(_random.Random):
             raise TypeError('Cannot specify both weights and cumulative weights')
         if len(cum_weights) != n:
             raise ValueError('The number of weights does not match the population')
-        bisect = _bisect
         total = cum_weights[-1] + 0.0   # convert to float
+        if total <= 0.0:
+            raise ValueError('Total of weights must be greater than zero')
+        bisect = _bisect
         hi = n - 1
         return [population[bisect(cum_weights, random() * total, 0, hi)]
                 for i in _repeat(None, k)]

--- a/Lib/test/test_random.py
+++ b/Lib/test/test_random.py
@@ -241,6 +241,11 @@ class TestBasicOps:
         choices = self.gen.choices
         choices(population=[1, 2], weights=[1e-323, 1e-323], k=5000)
 
+    def test_choices_with_all_zero_weights(self):
+        # See issue #38881
+        with self.assertRaises(ValueError):
+            self.gen.choices('AB', [0.0, 0.0])
+
     def test_gauss(self):
         # Ensure that the seed() method initializes all the hidden state.  In
         # particular, through 2.2.1 it failed to reset a piece of state used

--- a/Misc/NEWS.d/next/Library/2019-11-22-20-03-46.bpo-38881.7HV1Q0.rst
+++ b/Misc/NEWS.d/next/Library/2019-11-22-20-03-46.bpo-38881.7HV1Q0.rst
@@ -1,0 +1,1 @@
+random.choices() now raises a ValueError when all the weights are zero.


### PR DESCRIPTION
…17362)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
