### PR TITLE
Fix compiler warning in Objects/unicodeobject.c (GH-17440)

### DIFF
--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -15950,7 +15950,7 @@ _PyUnicode_Fini(PyThreadState *tstate)
     interp->fs_codec.encoding = NULL;
     PyMem_RawFree(interp->fs_codec.errors);
     interp->fs_codec.errors = NULL;
-    interp->config.filesystem_errors = _Py_ERROR_UNKNOWN;
+    interp->config.filesystem_errors = (wchar_t *)_Py_ERROR_UNKNOWN;
 }
 
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
