### PR TITLE
bpo-36820: Break unnecessary cycle in socket.py, codeop.py and dyld.p…

### DIFF
--- a/Lib/codeop.py
+++ b/Lib/codeop.py
@@ -93,10 +93,13 @@ def _maybe_compile(compiler, source, filename, symbol):
     except SyntaxError as e:
         err2 = e
 
-    if code:
-        return code
-    if not code1 and repr(err1) == repr(err2):
-        raise err1
+    try:
+        if code:
+            return code
+        if not code1 and repr(err1) == repr(err2):
+            raise err1
+    finally:
+        err1 = err2 = None
 
 def _compile(source, filename, symbol):
     return compile(source, filename, symbol, PyCF_DONT_IMPLY_DEDENT)

--- a/Lib/ctypes/macholib/dyld.py
+++ b/Lib/ctypes/macholib/dyld.py
@@ -149,6 +149,8 @@ def framework_find(fn, executable_path=None, env=None):
         return dyld_find(fn, executable_path=executable_path, env=env)
     except ValueError:
         raise error
+    finally:
+        error = None
 
 def test_dyld_find():
     env = {}

--- a/Lib/socket.py
+++ b/Lib/socket.py
@@ -839,7 +839,11 @@ def create_connection(address, timeout=_GLOBAL_DEFAULT_TIMEOUT,
                 sock.close()
 
     if err is not None:
-        raise err
+        try:
+            raise err
+        finally:
+            # Break explicitly a reference cycle
+            err = None
     else:
         raise error("getaddrinfo returns an empty list")
 

--- a/Misc/NEWS.d/next/Library/2019-05-06-15-34-17.bpo-36820.Eh5mIB.rst
+++ b/Misc/NEWS.d/next/Library/2019-05-06-15-34-17.bpo-36820.Eh5mIB.rst
@@ -1,0 +1,3 @@
+Break cycle generated when saving an exception in socket.py, codeop.py and
+dyld.py as they keep alive not only the exception but user objects through
+the ``__traceback__`` attribute. Patch by Mario Corchero.


### PR DESCRIPTION
…y (GH-13135)

Break cycle generated when saving an exception in socket.py, codeop.py and dyld.py as they keep alive not only the exception but user objects through the ``__traceback__`` attribute.


https://bugs.python.org/issue36820



Automerge-Triggered-By: @pablogsal

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
