### PR TITLE
bpo-38979: fix ContextVar "__class_getitem__" method (GH-17497)

### DIFF
--- a/Lib/test/test_context.py
+++ b/Lib/test/test_context.py
@@ -38,9 +38,6 @@ class ContextTest(unittest.TestCase):
 
         self.assertNotEqual(hash(c), hash('aaa'))
 
-    def test_context_var_new_2(self):
-        self.assertIsNone(contextvars.ContextVar[int])
-
     @isolated_context
     def test_context_var_repr_1(self):
         c = contextvars.ContextVar('a')
@@ -360,6 +357,10 @@ class ContextTest(unittest.TestCase):
         finally:
             tp.shutdown()
         self.assertEqual(results, list(range(10)))
+
+    def test_contextvar_getitem(self):
+        clss = contextvars.ContextVar
+        self.assertEqual(clss[str], clss)
 
 
 # HAMT Tests

--- a/Misc/NEWS.d/next/Library/2019-12-07-16-32-42.bpo-38979.q0sIHy.rst
+++ b/Misc/NEWS.d/next/Library/2019-12-07-16-32-42.bpo-38979.q0sIHy.rst
@@ -1,0 +1,1 @@
+Return class from ``ContextVar.__class_getitem__`` to simplify subclassing.

--- a/Python/context.c
+++ b/Python/context.c
@@ -1024,9 +1024,10 @@ _contextvars_ContextVar_reset(PyContextVar *self, PyObject *token)
 
 
 static PyObject *
-contextvar_cls_getitem(PyObject *self, PyObject *args)
+contextvar_cls_getitem(PyObject *self, PyObject *arg)
 {
-    Py_RETURN_NONE;
+    Py_INCREF(self);
+    return self;
 }
 
 static PyMemberDef PyContextVar_members[] = {
@@ -1039,7 +1040,7 @@ static PyMethodDef PyContextVar_methods[] = {
     _CONTEXTVARS_CONTEXTVAR_SET_METHODDEF
     _CONTEXTVARS_CONTEXTVAR_RESET_METHODDEF
     {"__class_getitem__", contextvar_cls_getitem,
-        METH_VARARGS | METH_STATIC, NULL},
+        METH_O | METH_CLASS, NULL},
     {NULL, NULL}
 };
 


### PR DESCRIPTION
now contextvars.ContextVar "__class_getitem__" method returns ContextVar class, not None. 


https://bugs.python.org/issue38979



Automerge-Triggered-By: @asvetlov

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
