### PR TITLE
bpo-38858: Small integer per interpreter (GH-17315)

### DIFF
--- a/Include/internal/pycore_pylifecycle.h
+++ b/Include/internal/pycore_pylifecycle.h
@@ -33,7 +33,7 @@ PyAPI_FUNC(int) _Py_IsLocaleCoercionTarget(const char *ctype_loc);
 
 extern PyStatus _PyUnicode_Init(void);
 extern int _PyStructSequence_Init(void);
-extern int _PyLong_Init(void);
+extern int _PyLong_Init(PyThreadState *tstate);
 extern PyStatus _PyFaulthandler_Init(int enable);
 extern int _PyTraceMalloc_Init(int enable);
 extern PyObject * _PyBuiltin_Init(PyThreadState *tstate);
@@ -76,7 +76,7 @@ extern void _PyGC_Fini(PyThreadState *tstate);
 extern void _PyType_Fini(void);
 extern void _Py_HashRandomization_Fini(void);
 extern void _PyUnicode_Fini(PyThreadState *tstate);
-extern void _PyLong_Fini(void);
+extern void _PyLong_Fini(PyThreadState *tstate);
 extern void _PyFaulthandler_Fini(void);
 extern void _PyHash_Fini(void);
 extern void _PyTraceMalloc_Fini(void);

--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -56,6 +56,9 @@ struct _ceval_runtime_state {
 
 typedef PyObject* (*_PyFrameEvalFunction)(struct _frame *, int);
 
+#define _PY_NSMALLPOSINTS           257
+#define _PY_NSMALLNEGINTS           5
+
 // The PyInterpreterState typedef is in Include/pystate.h.
 struct _is {
 
@@ -139,6 +142,15 @@ struct _is {
             int atbol;
         } listnode;
     } parser;
+
+#if _PY_NSMALLNEGINTS + _PY_NSMALLPOSINTS > 0
+    /* Small integers are preallocated in this array so that they
+       can be shared.
+       The integers that are preallocated are those in the range
+       -_PY_NSMALLNEGINTS (inclusive) to _PY_NSMALLPOSINTS (not inclusive).
+    */
+    PyLongObject* small_ints[_PY_NSMALLNEGINTS + _PY_NSMALLPOSINTS];
+#endif
 };
 
 PyAPI_FUNC(struct _is*) _PyInterpreterState_LookUpID(PY_INT64_T);

--- a/Misc/NEWS.d/next/Core and Builtins/2019-11-21-09-02-49.bpo-38858.bDLH04.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-11-21-09-02-49.bpo-38858.bDLH04.rst
@@ -1,0 +1,5 @@
+Each Python subinterpreter now has its own "small integer singletons":
+numbers in [-5; 257] range. It is no longer possible to change the number of
+small integers at build time by overriding ``NSMALLNEGINTS`` and
+``NSMALLPOSINTS`` macros: macros should now be modified manually in
+``pycore_pystate.h`` header file.

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -576,10 +576,11 @@ pycore_init_types(PyThreadState *tstate)
         if (_PyStatus_EXCEPTION(status)) {
             return status;
         }
+    }
 
-        if (!_PyLong_Init()) {
-            return _PyStatus_ERR("can't init longs");
-        }
+
+    if (!_PyLong_Init(tstate)) {
+        return _PyStatus_ERR("can't init longs");
     }
 
     if (is_main_interp) {
@@ -1251,7 +1252,11 @@ finalize_interp_types(PyThreadState *tstate, int is_main_interp)
         _PyList_Fini();
         _PySet_Fini();
         _PyBytes_Fini();
-        _PyLong_Fini();
+    }
+
+    _PyLong_Fini(tstate);
+
+    if (is_main_interp) {
         _PyFloat_Fini();
         _PyDict_Fini();
         _PySlice_Fini();


### PR DESCRIPTION
Each Python subinterpreter now has its own "small integer
singletons": numbers in [-5; 257] range.

It is no longer possible to change the number of small integers at
build time by overriding NSMALLNEGINTS and NSMALLPOSINTS macros:
macros should now be modified manually in pycore_pystate.h header
file.

For now, continue to share _PyLong_Zero and _PyLong_One singletons
between all subinterpreters.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
