### PR TITLE
bpo-38918: Add __module__ entry for function & method type in inspect…

### DIFF
--- a/Doc/library/inspect.rst
+++ b/Doc/library/inspect.rst
@@ -70,6 +70,9 @@ attributes:
 |           |                   | method is bound, or       |
 |           |                   | ``None``                  |
 +-----------+-------------------+---------------------------+
+|           | __module__        | name of module in which   |
+|           |                   | this method was defined   |
++-----------+-------------------+---------------------------+
 | function  | __doc__           | documentation string      |
 +-----------+-------------------+---------------------------+
 |           | __name__          | name with which this      |
@@ -97,6 +100,9 @@ attributes:
 |           |                   | ``"return"`` key is       |
 |           |                   | reserved for return       |
 |           |                   | annotations.              |
++-----------+-------------------+---------------------------+
+|           | __module__        | name of module in which   |
+|           |                   | this function was defined |
 +-----------+-------------------+---------------------------+
 | traceback | tb_frame          | frame object at this      |
 |           |                   | level                     |

--- a/Misc/NEWS.d/next/Documentation/2019-12-15-22-04-41.bpo-38918.8JnDTS.rst
+++ b/Misc/NEWS.d/next/Documentation/2019-12-15-22-04-41.bpo-38918.8JnDTS.rst
@@ -1,0 +1,3 @@
+Add an entry for ``__module__`` in the "function" & "method" sections of the
+`inspect docs types and members table
+<https://docs.python.org/3/library/inspect.html#types-and-members>`_


### PR DESCRIPTION
… docs table (GH-17408)

Adds` __module__ ` entries for function & method types in inspect docs table.





https://bugs.python.org/issue38918

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
