### PR TITLE
bpo-38878: Fix os.PathLike __subclasshook__ (GH-17336)

### DIFF
--- a/Lib/os.py
+++ b/Lib/os.py
@@ -26,6 +26,8 @@ import abc
 import sys
 import stat as st
 
+from _collections_abc import _check_methods
+
 _names = sys.builtin_module_names
 
 # Note:  more names are added to __all__ later.
@@ -1070,7 +1072,9 @@ class PathLike(abc.ABC):
 
     @classmethod
     def __subclasshook__(cls, subclass):
-        return hasattr(subclass, '__fspath__')
+        if cls is PathLike:
+            return _check_methods(subclass, '__fspath__')
+        return NotImplemented
 
     def __class_getitem__(cls, type):
         return cls

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -4048,6 +4048,14 @@ class TestPEP519(unittest.TestCase):
         self.assertRaises(ZeroDivisionError, self.fspath,
                           FakePath(ZeroDivisionError()))
 
+    def test_pathlike_subclasshook(self):
+        # bpo-38878: subclasshook causes subclass checks
+        # true on abstract implementation.
+        class A(os.PathLike):
+            pass
+        self.assertFalse(issubclass(FakePath, A))
+        self.assertTrue(issubclass(FakePath, os.PathLike))
+
     def test_pathlike_class_getitem(self):
         self.assertIs(os.PathLike[bytes], os.PathLike)
 

--- a/Misc/NEWS.d/next/Library/2019-11-22-12-08-52.bpo-38878.EJ0cFf.rst
+++ b/Misc/NEWS.d/next/Library/2019-11-22-12-08-52.bpo-38878.EJ0cFf.rst
@@ -1,0 +1,2 @@
+Fixed __subclasshook__ of :class:`os.PathLike` to return a correct result
+upon inheritence. Patch by Bar Harel.


### PR DESCRIPTION
Quick subclasshook fix using the same method is being used in collections.abc (up to a certain degree).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
