### PR TITLE
Minor C API documentation improvements. (GH-17696)

### DIFF
--- a/Doc/c-api/iter.rst
+++ b/Doc/c-api/iter.rst
@@ -29,7 +29,7 @@ something like this::
        /* propagate error */
    }
 
-   while (item = PyIter_Next(iterator)) {
+   while ((item = PyIter_Next(iterator))) {
        /* do something with item */
        ...
        /* release reference when done */

--- a/Doc/includes/custom.c
+++ b/Doc/includes/custom.c
@@ -37,7 +37,7 @@ PyInit_custom(void)
     Py_INCREF(&CustomType);
     if (PyModule_AddObject(m, "Custom", (PyObject *) &CustomType) < 0) {
         Py_DECREF(&CustomType);
-        PY_DECREF(m);
+        Py_DECREF(m);
         return NULL;
     }
 


### PR DESCRIPTION
The added parentheses around the PyIter_Next assignment suppress the following warning which gcc throws without:
```
warning: using the result of an assignment as a condition without parentheses [-Wparentheses]
```
The other change is a typo fix

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
