### PR TITLE
Fix SystemError when nested function has annotation on positional-onl…

### DIFF
--- a/Lib/test/test_positional_only_arg.py
+++ b/Lib/test/test_positional_only_arg.py
@@ -15,6 +15,10 @@ def global_pos_only_and_normal(a, /, b):
 def global_pos_only_defaults(a=1, /, b=2):
     return a, b
 
+def global_inner_has_pos_only():
+    def f(x: int, /): ...
+    return f
+
 
 class PositionalOnlyTestCase(unittest.TestCase):
 
@@ -411,6 +415,9 @@ class PositionalOnlyTestCase(unittest.TestCase):
                 return super().method()
 
         self.assertEqual(C().method(), sentinel)
+
+    def test_annotations(self):
+        assert global_inner_has_pos_only().__annotations__ == {'x': int}
 
 
 if __name__ == "__main__":

--- a/Misc/NEWS.d/next/Core and Builtins/2020-01-04-17-25-34.bpo-39215.xiqiIz.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-01-04-17-25-34.bpo-39215.xiqiIz.rst
@@ -1,0 +1,2 @@
+Fix ``SystemError`` when nested function has annotation on positional-only
+argument - by Anthony Sottile.

--- a/Python/symtable.c
+++ b/Python/symtable.c
@@ -1717,6 +1717,8 @@ static int
 symtable_visit_annotations(struct symtable *st, stmt_ty s,
                            arguments_ty a, expr_ty returns)
 {
+    if (a->posonlyargs && !symtable_visit_argannotations(st, a->posonlyargs))
+        return 0;
     if (a->args && !symtable_visit_argannotations(st, a->args))
         return 0;
     if (a->vararg && a->vararg->annotation)


### PR DESCRIPTION
…y argument (GH-17826)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
