### PR TITLE
bpo-39259: nntplib.NNTP/NNTP_SSL now reject timeout = 0 (GH-17936)

### DIFF
--- a/Doc/library/nntplib.rst
+++ b/Doc/library/nntplib.rst
@@ -93,6 +93,10 @@ The module itself defines the following classes:
    .. versionchanged:: 3.3
       Support for the :keyword:`with` statement was added.
 
+   .. versionchanged:: 3.9
+      If the *timeout* parameter is set to be zero, it will raise a
+      :class:`ValueError` to prevent the creation of a non-blocking socket.
+
 .. class:: NNTP_SSL(host, port=563, user=None, password=None, ssl_context=None, readermode=None, usenetrc=False, [timeout])
 
    Return a new :class:`NNTP_SSL` object, representing an encrypted
@@ -121,6 +125,10 @@ The module itself defines the following classes:
       The class now supports hostname check with
       :attr:`ssl.SSLContext.check_hostname` and *Server Name Indication* (see
       :data:`ssl.HAS_SNI`).
+
+   .. versionchanged:: 3.9
+      If the *timeout* parameter is set to be zero, it will raise a
+      :class:`ValueError` to prevent the creation of a non-blocking socket.
 
 .. exception:: NNTPError
 

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -177,6 +177,13 @@ with this change. The overridden methods of :class:`~imaplib.IMAP4_SSL` and
 :class:`~imaplib.IMAP4_stream` were applied to this change.
 (Contributed by Dong-hee Na in :issue:`38615`.)
 
+nntplib
+-------
+
+:class:`~nntplib.NNTP` and :class:`~nntplib.NNTP_SSL` now raise a :class:`ValueError`
+if the given timeout for their constructor is zero to prevent the creation of
+a non-blocking socket. (Contributed by Dong-hee Na in :issue:`39259`.)
+
 os
 --
 

--- a/Lib/nntplib.py
+++ b/Lib/nntplib.py
@@ -1056,6 +1056,8 @@ class NNTP(_NNTPBase):
             raise
 
     def _create_socket(self, timeout):
+        if timeout is not None and not timeout:
+            raise ValueError('Non-blocking socket (timeout=0) is not supported')
         sys.audit("nntplib.connect", self, self.host, self.port)
         return socket.create_connection((self.host, self.port), timeout)
 

--- a/Lib/test/test_nntplib.py
+++ b/Lib/test/test_nntplib.py
@@ -258,6 +258,10 @@ class NetworkedNNTPTestsMixin:
             # value
             setattr(cls, name, wrap_meth(meth))
 
+    def test_timeout(self):
+        with self.assertRaises(ValueError):
+            self.NNTP_CLASS(self.NNTP_HOST, timeout=0, usenetrc=False)
+
     def test_with_statement(self):
         def is_connected():
             if not hasattr(server, 'file'):

--- a/Misc/NEWS.d/next/Library/2020-01-11-00-32-45.bpo-39259._S5VjC.rst
+++ b/Misc/NEWS.d/next/Library/2020-01-11-00-32-45.bpo-39259._S5VjC.rst
@@ -1,0 +1,3 @@
+:class:`~nntplib.NNTP` and :class:`~nntplib.NNTP_SSL` now raise a
+:class:`ValueError` if the given timeout for their constructor is zero to
+prevent the creation of a non-blocking socket. Patch by Dong-hee Na.


### PR DESCRIPTION
nntplib.NNTP and nntplib.NNTP_SSL now raise a ValueError
if the given timeout for their constructor is zero to
prevent the creation of a non-blocking socket.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
