### PR TITLE
bpo-39164: Fix compiler warning in PyErr_GetExcInfo() (GH-18010)

### DIFF
--- a/Python/errors.c
+++ b/Python/errors.c
@@ -451,7 +451,7 @@ void
 PyErr_GetExcInfo(PyObject **p_type, PyObject **p_value, PyObject **p_traceback)
 {
     PyThreadState *tstate = _PyThreadState_GET();
-    return _PyErr_GetExcInfo(tstate, p_type, p_value, p_traceback);
+    _PyErr_GetExcInfo(tstate, p_type, p_value, p_traceback);
 }
 
 void


### PR DESCRIPTION
The function has no return value.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
