### PR TITLE
bpo-39372: Clean header files of declared interfaces with no implemen…

### DIFF
--- a/Include/bytesobject.h
+++ b/Include/bytesobject.h
@@ -106,28 +106,6 @@ PyAPI_FUNC(int) PyBytes_AsStringAndSize(
                            strings) */
     );
 
-/* Using the current locale, insert the thousands grouping
-   into the string pointed to by buffer.  For the argument descriptions,
-   see Objects/stringlib/localeutil.h */
-#ifndef Py_LIMITED_API
-PyAPI_FUNC(Py_ssize_t) _PyBytes_InsertThousandsGroupingLocale(char *buffer,
-                                                   Py_ssize_t n_buffer,
-                                                   char *digits,
-                                                   Py_ssize_t n_digits,
-                                                   Py_ssize_t min_width);
-
-/* Using explicit passed-in values, insert the thousands grouping
-   into the string pointed to by buffer.  For the argument descriptions,
-   see Objects/stringlib/localeutil.h */
-PyAPI_FUNC(Py_ssize_t) _PyBytes_InsertThousandsGrouping(char *buffer,
-                                                   Py_ssize_t n_buffer,
-                                                   char *digits,
-                                                   Py_ssize_t n_digits,
-                                                   Py_ssize_t min_width,
-                                                   const char *grouping,
-                                                   const char *thousands_sep);
-#endif
-
 /* Flags used by string formatting */
 #define F_LJUST (1<<0)
 #define F_SIGN  (1<<1)

--- a/Include/cpython/pylifecycle.h
+++ b/Include/cpython/pylifecycle.h
@@ -32,14 +32,6 @@ PyAPI_FUNC(int) _Py_IsCoreInitialized(void);
 
 PyAPI_FUNC(PyStatus) Py_InitializeFromConfig(
     const PyConfig *config);
-PyAPI_FUNC(PyStatus) _Py_InitializeFromArgs(
-    const PyConfig *config,
-    Py_ssize_t argc,
-    char * const *argv);
-PyAPI_FUNC(PyStatus) _Py_InitializeFromWideArgs(
-    const PyConfig *config,
-    Py_ssize_t argc,
-    wchar_t * const *argv);
 PyAPI_FUNC(PyStatus) _Py_InitializeMain(void);
 
 PyAPI_FUNC(int) Py_RunMain(void);

--- a/Include/floatobject.h
+++ b/Include/floatobject.h
@@ -88,15 +88,6 @@ PyAPI_FUNC(int) _PyFloat_Pack2(double x, unsigned char *p, int le);
 PyAPI_FUNC(int) _PyFloat_Pack4(double x, unsigned char *p, int le);
 PyAPI_FUNC(int) _PyFloat_Pack8(double x, unsigned char *p, int le);
 
-/* Needed for the old way for marshal to store a floating point number.
-   Returns the string length copied into p, -1 on error.
- */
-PyAPI_FUNC(int) _PyFloat_Repr(double x, char *p, size_t len);
-
-/* Used to get the important decimal digits of a double */
-PyAPI_FUNC(int) _PyFloat_Digits(char *buf, double v, int *signum);
-PyAPI_FUNC(void) _PyFloat_DigitsInit(void);
-
 /* The unpack routines read 2, 4 or 8 bytes, starting at p.  le is a bool
  * argument, true if the string is in little-endian format (exponent
  * last, at p+1, p+3 or p+7), false if big-endian (exponent first, at p).

--- a/Include/frameobject.h
+++ b/Include/frameobject.h
@@ -67,10 +67,6 @@ PyFrameObject* _PyFrame_New_NoTrack(PyThreadState *, PyCodeObject *,
 PyAPI_FUNC(void) PyFrame_BlockSetup(PyFrameObject *, int, int, int);
 PyAPI_FUNC(PyTryBlock *) PyFrame_BlockPop(PyFrameObject *);
 
-/* Extend the value stack */
-
-PyAPI_FUNC(PyObject **) PyFrame_ExtendStack(PyFrameObject *, int, int);
-
 /* Conversions between "fast locals" and locals in dictionary */
 
 PyAPI_FUNC(void) PyFrame_LocalsToFast(PyFrameObject *, int);

--- a/Include/genobject.h
+++ b/Include/genobject.h
@@ -58,8 +58,6 @@ typedef struct {
 PyAPI_DATA(PyTypeObject) PyCoro_Type;
 PyAPI_DATA(PyTypeObject) _PyCoroWrapper_Type;
 
-PyAPI_DATA(PyTypeObject) _PyAIterWrapper_Type;
-
 #define PyCoro_CheckExact(op) (Py_TYPE(op) == &PyCoro_Type)
 PyObject *_PyCoro_GetAwaitableIter(PyObject *o);
 PyAPI_FUNC(PyObject *) PyCoro_New(struct _frame *,

--- a/Include/import.h
+++ b/Include/import.h
@@ -81,8 +81,6 @@ PyAPI_FUNC(int) PyImport_ImportFrozenModule(
     const char *name            /* UTF-8 encoded string */
     );
 
-PyAPI_DATA(PyTypeObject) PyNullImporter_Type;
-
 PyAPI_FUNC(int) PyImport_AppendInittab(
     const char *name,           /* ASCII encoded string */
     PyObject* (*initfunc)(void)

--- a/Include/internal/pycore_pathconfig.h
+++ b/Include/internal/pycore_pathconfig.h
@@ -47,8 +47,6 @@ PyAPI_DATA(wchar_t*) _Py_dll_path;
 #endif
 
 extern void _PyPathConfig_ClearGlobal(void);
-extern PyStatus _PyPathConfig_SetGlobal(
-    const struct _PyPathConfig *pathconfig);
 
 extern PyStatus _PyPathConfig_Calculate(
     _PyPathConfig *pathconfig,

--- a/Include/iterobject.h
+++ b/Include/iterobject.h
@@ -7,7 +7,6 @@ extern "C" {
 
 PyAPI_DATA(PyTypeObject) PySeqIter_Type;
 PyAPI_DATA(PyTypeObject) PyCallIter_Type;
-PyAPI_DATA(PyTypeObject) PyCmpWrapper_Type;
 
 #define PySeqIter_Check(op) (Py_TYPE(op) == &PySeqIter_Type)
 

--- a/Include/listobject.h
+++ b/Include/listobject.h
@@ -43,7 +43,6 @@ typedef struct {
 PyAPI_DATA(PyTypeObject) PyList_Type;
 PyAPI_DATA(PyTypeObject) PyListIter_Type;
 PyAPI_DATA(PyTypeObject) PyListRevIter_Type;
-PyAPI_DATA(PyTypeObject) PySortWrapper_Type;
 
 #define PyList_Check(op) \
     PyType_FastSubclass(Py_TYPE(op), Py_TPFLAGS_LIST_SUBCLASS)

--- a/Include/methodobject.h
+++ b/Include/methodobject.h
@@ -22,8 +22,6 @@ typedef PyObject *(*PyCFunctionWithKeywords)(PyObject *, PyObject *,
 typedef PyObject *(*_PyCFunctionFastWithKeywords) (PyObject *,
                                                    PyObject *const *, Py_ssize_t,
                                                    PyObject *);
-typedef PyObject *(*PyNoArgsFunction)(PyObject *);
-
 PyAPI_FUNC(PyCFunction) PyCFunction_GetFunction(PyObject *);
 PyAPI_FUNC(PyObject *) PyCFunction_GetSelf(PyObject *);
 PyAPI_FUNC(int) PyCFunction_GetFlags(PyObject *);

--- a/Include/pythread.h
+++ b/Include/pythread.h
@@ -3,7 +3,6 @@
 #define Py_PYTHREAD_H
 
 typedef void *PyThread_type_lock;
-typedef void *PyThread_type_sema;
 
 #ifdef __cplusplus
 extern "C" {

--- a/Misc/NEWS.d/next/C API/2020-01-17-19-25-48.bpo-39372.hGJMY6.rst
+++ b/Misc/NEWS.d/next/C API/2020-01-17-19-25-48.bpo-39372.hGJMY6.rst
@@ -1,0 +1,8 @@
+Clean header files of interfaces defined but with no implementation. The
+public API symbols being removed are:
+``_PyBytes_InsertThousandsGroupingLocale``,
+``_PyBytes_InsertThousandsGrouping``, ``_Py_InitializeFromArgs``,
+``_Py_InitializeFromWideArgs``, ``_PyFloat_Repr``, ``_PyFloat_Digits``,
+``_PyFloat_DigitsInit``, ``PyFrame_ExtendStack``, ``_PyAIterWrapper_Type``,
+``PyNullImporter_Type``, ``PyCmpWrapper_Type``, ``PySortWrapper_Type``,
+``PyNoArgsFunction``.

--- a/Objects/stringlib/asciilib.h
+++ b/Objects/stringlib/asciilib.h
@@ -24,6 +24,3 @@
 
 #define STRINGLIB_TOSTR          PyObject_Str
 #define STRINGLIB_TOASCII        PyObject_ASCII
-
-#define _Py_InsertThousandsGrouping _PyUnicode_ascii_InsertThousandsGrouping
-

--- a/Objects/stringlib/ucs1lib.h
+++ b/Objects/stringlib/ucs1lib.h
@@ -24,7 +24,3 @@
 
 #define STRINGLIB_TOSTR          PyObject_Str
 #define STRINGLIB_TOASCII        PyObject_ASCII
-
-#define _Py_InsertThousandsGrouping _PyUnicode_ucs1_InsertThousandsGrouping
-
-

--- a/Objects/stringlib/ucs2lib.h
+++ b/Objects/stringlib/ucs2lib.h
@@ -24,6 +24,3 @@
 
 #define STRINGLIB_TOSTR          PyObject_Str
 #define STRINGLIB_TOASCII        PyObject_ASCII
-
-#define _Py_InsertThousandsGrouping _PyUnicode_ucs2_InsertThousandsGrouping
-

--- a/Objects/stringlib/ucs4lib.h
+++ b/Objects/stringlib/ucs4lib.h
@@ -25,5 +25,3 @@
 #define STRINGLIB_TOSTR          PyObject_Str
 #define STRINGLIB_TOASCII        PyObject_ASCII
 
-#define _Py_InsertThousandsGrouping _PyUnicode_ucs4_InsertThousandsGrouping
-

--- a/Objects/stringlib/undef.h
+++ b/Objects/stringlib/undef.h
@@ -6,6 +6,5 @@
 #undef  STRINGLIB_STR
 #undef  STRINGLIB_LEN
 #undef  STRINGLIB_NEW
-#undef  _Py_InsertThousandsGrouping
 #undef STRINGLIB_IS_UNICODE
 


### PR DESCRIPTION
…tations (GH-18037)

The public API symbols being removed are:

_PyBytes_InsertThousandsGroupingLocale, _PyBytes_InsertThousandsGrouping, _Py_InitializeFromArgs, _Py_InitializeFromWideArgs, _PyFloat_Repr, _PyFloat_Digits,
_PyFloat_DigitsInit, PyFrame_ExtendStack, _PyAIterWrapper_Type, PyNullImporter_Type, PyCmpWrapper_Type, PySortWrapper_Type, PyNoArgsFunction.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
