### PR TITLE
bpo-25597: Ensure wraps' return value is used for magic methods in Ma…

### DIFF
--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -2033,6 +2033,12 @@ _side_effect_methods = {
 
 
 def _set_return_value(mock, method, name):
+    # If _mock_wraps is present then attach it so that wrapped object
+    # is used for return value is used when called.
+    if mock._mock_wraps is not None:
+        method._mock_wraps = getattr(mock._mock_wraps, name)
+        return
+
     fixed = _return_values.get(name, DEFAULT)
     if fixed is not DEFAULT:
         method.return_value = fixed

--- a/Misc/NEWS.d/next/Library/2019-09-12-12-11-05.bpo-25597.mPMzVx.rst
+++ b/Misc/NEWS.d/next/Library/2019-09-12-12-11-05.bpo-25597.mPMzVx.rst
@@ -1,0 +1,3 @@
+Ensure, if ``wraps`` is supplied to :class:`unittest.mock.MagicMock`, it is used
+to calculate return values for the magic methods instead of using the default
+return values. Patch by Karthikeyan Singaravelan.


### PR DESCRIPTION
…gicMock (#16029)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
