### PR TITLE
bpo-35081: Move bytes_methods.h to the internal C API (GH-18492)

### DIFF
--- a/Include/internal/pycore_bytes_methods.h
+++ b/Include/internal/pycore_bytes_methods.h
@@ -2,6 +2,10 @@
 #ifndef Py_BYTES_CTYPE_H
 #define Py_BYTES_CTYPE_H
 
+#ifndef Py_BUILD_CORE
+#  error "this header requires Py_BUILD_CORE define"
+#endif
+
 /*
  * The internal implementation behind PyBytes (bytes) and PyByteArray (bytearray)
  * methods of the given names, they operate on ASCII byte strings.

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -970,7 +970,6 @@ PYTHON_HEADERS= \
 		$(srcdir)/Include/bltinmodule.h \
 		$(srcdir)/Include/boolobject.h \
 		$(srcdir)/Include/bytearrayobject.h \
-		$(srcdir)/Include/bytes_methods.h \
 		$(srcdir)/Include/bytesobject.h \
 		$(srcdir)/Include/cellobject.h \
 		$(srcdir)/Include/ceval.h \
@@ -1077,6 +1076,7 @@ PYTHON_HEADERS= \
 		\
 		$(srcdir)/Include/internal/pycore_accu.h \
 		$(srcdir)/Include/internal/pycore_atomic.h \
+		$(srcdir)/Include/internal/pycore_bytes_methods.h \
 		$(srcdir)/Include/internal/pycore_call.h \
 		$(srcdir)/Include/internal/pycore_ceval.h \
 		$(srcdir)/Include/internal/pycore_code.h \

--- a/Misc/NEWS.d/next/C API/2020-02-12-21-38-49.bpo-35081.5tj1yC.rst
+++ b/Misc/NEWS.d/next/C API/2020-02-12-21-38-49.bpo-35081.5tj1yC.rst
@@ -1,0 +1,3 @@
+Move the ``bytes_methods.h`` header file to the internal C API as
+``pycore_bytes_methods.h``: it only contains private symbols (prefixed by
+``_Py``), except of the ``PyDoc_STRVAR_shared()`` macro.

--- a/Objects/bytearrayobject.c
+++ b/Objects/bytearrayobject.c
@@ -2,11 +2,11 @@
 
 #define PY_SSIZE_T_CLEAN
 #include "Python.h"
+#include "pycore_bytes_methods.h"
 #include "pycore_object.h"
 #include "pycore_pymem.h"
 #include "pycore_pystate.h"
 #include "structmember.h"
-#include "bytes_methods.h"
 #include "bytesobject.h"
 #include "pystrhex.h"
 

--- a/Objects/bytes_methods.c
+++ b/Objects/bytes_methods.c
@@ -1,6 +1,6 @@
 #define PY_SSIZE_T_CLEAN
 #include "Python.h"
-#include "bytes_methods.h"
+#include "pycore_bytes_methods.h"
 
 PyDoc_STRVAR_shared(_Py_isspace__doc__,
 "B.isspace() -> bool\n\

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -3,11 +3,11 @@
 #define PY_SSIZE_T_CLEAN
 
 #include "Python.h"
+#include "pycore_bytes_methods.h"
 #include "pycore_object.h"
 #include "pycore_pymem.h"
 #include "pycore_pystate.h"
 
-#include "bytes_methods.h"
 #include "pystrhex.h"
 #include <stddef.h>
 

--- a/Objects/stringlib/ctype.h
+++ b/Objects/stringlib/ctype.h
@@ -2,7 +2,7 @@
 # error "ctype.h only compatible with byte-wise strings"
 #endif
 
-#include "bytes_methods.h"
+#include "pycore_bytes_methods.h"
 
 static PyObject*
 stringlib_isspace(PyObject *self, PyObject *Py_UNUSED(ignored))

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -40,6 +40,7 @@ OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 #define PY_SSIZE_T_CLEAN
 #include "Python.h"
+#include "pycore_bytes_methods.h"
 #include "pycore_fileutils.h"
 #include "pycore_initconfig.h"
 #include "pycore_object.h"
@@ -47,7 +48,6 @@ OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include "pycore_pylifecycle.h"
 #include "pycore_pystate.h"
 #include "ucnhash.h"
-#include "bytes_methods.h"
 #include "stringlib/eq.h"
 
 #ifdef MS_WINDOWS

--- a/PCbuild/pythoncore.vcxproj
+++ b/PCbuild/pythoncore.vcxproj
@@ -115,7 +115,6 @@
     <ClInclude Include="..\Include\ast.h" />
     <ClInclude Include="..\Include\bitset.h" />
     <ClInclude Include="..\Include\boolobject.h" />
-    <ClInclude Include="..\Include\bytes_methods.h" />
     <ClInclude Include="..\Include\bytearrayobject.h" />
     <ClInclude Include="..\Include\bytesobject.h" />
     <ClInclude Include="..\Include\cellobject.h" />
@@ -161,6 +160,7 @@
     <ClInclude Include="..\Include\import.h" />
     <ClInclude Include="..\Include\internal\pycore_accu.h" />
     <ClInclude Include="..\Include\internal\pycore_atomic.h" />
+    <ClInclude Include="..\Include\internal\pycore_bytes_methods.h" />
     <ClInclude Include="..\Include\internal\pycore_call.h" />
     <ClInclude Include="..\Include\internal\pycore_ceval.h" />
     <ClInclude Include="..\Include\internal\pycore_code.h" />

--- a/PCbuild/pythoncore.vcxproj.filters
+++ b/PCbuild/pythoncore.vcxproj.filters
@@ -48,9 +48,6 @@
     <ClInclude Include="..\Include\boolobject.h">
       <Filter>Include</Filter>
     </ClInclude>
-    <ClInclude Include="..\Include\bytes_methods.h">
-      <Filter>Include</Filter>
-    </ClInclude>
     <ClInclude Include="..\Include\bytearrayobject.h">
       <Filter>Include</Filter>
     </ClInclude>
@@ -184,6 +181,9 @@
       <Filter>Include</Filter>
     </ClInclude>
     <ClInclude Include="..\Include\internal\pycore_atomic.h">
+      <Filter>Include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Include\internal\pycore_bytes_methods.h">
       <Filter>Include</Filter>
     </ClInclude>
     <ClInclude Include="..\Include\internal\pycore_call.h">


### PR DESCRIPTION
Move the bytes_methods.h header file to the internal C API as
pycore_bytes_methods.h: it only contains private symbols (prefixed by
"_Py"), except of the PyDoc_STRVAR_shared() macro.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
