### PR TITLE
bpo-39609: set the thread_name_prefix for the default asyncio executo…

### DIFF
--- a/Lib/asyncio/base_events.py
+++ b/Lib/asyncio/base_events.py
@@ -806,7 +806,9 @@ class BaseEventLoop(events.AbstractEventLoop):
             # Only check when the default executor is being used
             self._check_default_executor()
             if executor is None:
-                executor = concurrent.futures.ThreadPoolExecutor()
+                executor = concurrent.futures.ThreadPoolExecutor(
+                    thread_name_prefix='asyncio'
+                )
                 self._default_executor = executor
         return futures.wrap_future(
             executor.submit(func, *args), loop=self)

--- a/Misc/NEWS.d/next/Library/2020-02-11-19-45-31.bpo-39609.dk40Uw.rst
+++ b/Misc/NEWS.d/next/Library/2020-02-11-19-45-31.bpo-39609.dk40Uw.rst
@@ -1,0 +1,1 @@
+Add thread_name_prefix to default asyncio executor


### PR DESCRIPTION
…r (GH-18458)

Just a small debugging improvement to identify the asyncio executor threads.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
