### PR TITLE
bpo-13790: Change 'string' to 'specification' in format doc (GH-18690)

### DIFF
--- a/Doc/library/string.rst
+++ b/Doc/library/string.rst
@@ -302,9 +302,9 @@ specification is to be interpreted.
 Most built-in types implement the following options for format specifications,
 although some of the formatting options are only supported by the numeric types.
 
-A general convention is that an empty format string (``""``) produces
+A general convention is that an empty format specification produces
 the same result as if you had called :func:`str` on the value. A
-non-empty format string typically modifies the result.
+non-empty format specification typically modifies the result.
 
 The general form of a *standard format specifier* is:
 

--- a/Misc/NEWS.d/next/Documentation/2020-02-28-14-39-25.bpo-13790.hvLaRI.rst
+++ b/Misc/NEWS.d/next/Documentation/2020-02-28-14-39-25.bpo-13790.hvLaRI.rst
@@ -1,0 +1,1 @@
+Change 'string' to 'specification' in format doc.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
