### PR TITLE
bpo-39379: Remove reference to sys.path[0] being absolute path in wha…

### DIFF
--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -89,11 +89,10 @@ Other Language Changes
 
 * Python now gets the absolute path of the script filename specified on
   the command line (ex: ``python3 script.py``): the ``__file__`` attribute of
-  the :mod:`__main__` module and ``sys.path[0]`` become an
-  absolute path, rather than a relative path. These paths now remain valid
-  after the current directory is changed by :func:`os.chdir`. As a side effect,
-  a traceback also displays the absolute path for :mod:`__main__` module frames
-  in this case.
+  the :mod:`__main__` module became an absolute path, rather than a relative
+  path. These paths now remain valid after the current directory is changed
+  by :func:`os.chdir`. As a side effect, the traceback also displays the
+  absolute path for :mod:`__main__` module frames in this case.
   (Contributed by Victor Stinner in :issue:`20443`.)
 
 * In the :ref:`Python Development Mode <devmode>` and in debug build, the


### PR DESCRIPTION
…tsnew (GH-18561)

Remove reference to sys.path[0] being absolute path in whatsnew

Co-Authored-By: Kyle Stanley <aeros167@gmail.com>
Co-authored-by: blurb-it[bot] <43283697+blurb-it[bot]@users.noreply.github.com>
Co-authored-by: Kyle Stanley <aeros167@gmail.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
