### PR TITLE
bpo-38641: Add lib2to3 support for starred expressions in return/yiel…

### DIFF
--- a/Lib/lib2to3/Grammar.txt
+++ b/Lib/lib2to3/Grammar.txt
@@ -49,7 +49,7 @@ pass_stmt: 'pass'
 flow_stmt: break_stmt | continue_stmt | return_stmt | raise_stmt | yield_stmt
 break_stmt: 'break'
 continue_stmt: 'continue'
-return_stmt: 'return' [testlist]
+return_stmt: 'return' [testlist_star_expr]
 yield_stmt: yield_expr
 raise_stmt: 'raise' [test ['from' test | ',' test [',' test]]]
 import_stmt: import_name | import_from
@@ -151,4 +151,4 @@ testlist1: test (',' test)*
 encoding_decl: NAME
 
 yield_expr: 'yield' [yield_arg]
-yield_arg: 'from' test | testlist
+yield_arg: 'from' test | testlist_star_expr

--- a/Lib/lib2to3/tests/data/py3_test_grammar.py
+++ b/Lib/lib2to3/tests/data/py3_test_grammar.py
@@ -473,15 +473,27 @@ class GrammarTests(unittest.TestCase):
         test_inner()
 
     def testReturn(self):
-        # 'return' [testlist]
+        # 'return' [testlist_star_expr]
         def g1(): return
         def g2(): return 1
+        return_list = [2, 3]
+        def g3(): return 1, *return_list
         g1()
         x = g2()
+        x3 = g3()
         check_syntax_error(self, "class foo:return 1")
 
     def testYield(self):
+        # 'yield' [yield_arg]
+        def g1(): yield 1
+        yield_list = [2, 3]
+        def g2(): yield 1, *yield_list
+        def g3(): yield from iter(yield_list)
+        x1 = g1()
+        x2 = g2()
+        x3 = g3()
         check_syntax_error(self, "class foo:yield 1")
+        check_syntax_error(self, "def g4(): yield from *a")
 
     def testRaise(self):
         # 'raise' test [',' test]

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1914,5 +1914,6 @@ Jelle Zijlstra
 Gennadiy Zlobin
 Doug Zongker
 Peter Åstrand
+Vlad Emelianov
 
 (Entries should be added in rough alphabetical order by last names)

--- a/Misc/NEWS.d/next/Library/2019-10-30-15-31-09.bpo-38641.HrTL9k.rst
+++ b/Misc/NEWS.d/next/Library/2019-10-30-15-31-09.bpo-38641.HrTL9k.rst
@@ -1,0 +1,2 @@
+Added starred expressions support to ``return`` and ``yield`` statements for
+``lib2to3``. Patch by Vlad Emelianov.


### PR DESCRIPTION
…d statements (GH-16994)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
