### PR TITLE
 bpo-39885: IDLE context menu clears selection  (#18859)

### DIFF
--- a/Lib/idlelib/NEWS.txt
+++ b/Lib/idlelib/NEWS.txt
@@ -3,6 +3,9 @@ Released on 2020-10-05?
 ======================================
 
 
+bpo-39885: Since clicking to get an IDLE context menu moves the
+cursor, any text selection should be and now is cleared.
+
 bpo-39852: Edit "Go to line" now clears any selection, preventing
 accidental deletion.  It also updates Ln and Col on the status bar.
 

--- a/Lib/idlelib/editor.py
+++ b/Lib/idlelib/editor.py
@@ -499,6 +499,7 @@ class EditorWindow(object):
     rmenu = None
 
     def right_menu_event(self, event):
+        self.text.tag_remove("sel", "1.0", "end")
         self.text.mark_set("insert", "@%d,%d" % (event.x, event.y))
         if not self.rmenu:
             self.make_rmenu()

--- a/Misc/NEWS.d/next/IDLE/2020-03-08-14-27-36.bpo-39885.29ERiR.rst
+++ b/Misc/NEWS.d/next/IDLE/2020-03-08-14-27-36.bpo-39885.29ERiR.rst
@@ -1,0 +1,2 @@
+Since clicking to get an IDLE context menu moves the cursor,
+any text selection should be and now is cleared.


### PR DESCRIPTION
Since clicking to get an IDLE context menu moves the cursor,
any text selection should be and now is cleared.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
