### PR TITLE
bpo-43277: Add PySet_CheckExact to the C-API (GH-24598)

### DIFF
--- a/Doc/c-api/set.rst
+++ b/Doc/c-api/set.rst
@@ -65,6 +65,12 @@ the constructor functions work with any iterable Python object.
    Return true if *p* is a :class:`set` object, a :class:`frozenset` object, or an
    instance of a subtype.  This function always succeeds.
 
+.. c:function:: int PySet_CheckExact(PyObject *p)
+
+   Return true if *p* is a :class:`set` object but not an instance of a
+   subtype.  This function always succeeds.
+
+   .. versionadded:: 3.10
 
 .. c:function:: int PyAnySet_CheckExact(PyObject *p)
 

--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -893,6 +893,9 @@ New Features
 * The :c:func:`PyType_GetSlot` function can accept static types.
   (Contributed by Hai Shi and Petr Viktorin in :issue:`41073`.)
 
+* Add a new :c:func:`PySet_CheckExact` function to the C-API to check if an
+  object is an instance of :class:`set` but not an instance of a subtype.
+  (Contributed by Pablo Galindo in :issue:`43277`.)
 
 Porting to Python 3.10
 ----------------------

--- a/Include/setobject.h
+++ b/Include/setobject.h
@@ -88,18 +88,21 @@ PyAPI_FUNC(PyObject *) PySet_Pop(PyObject *set);
 PyAPI_FUNC(Py_ssize_t) PySet_Size(PyObject *anyset);
 
 #define PyFrozenSet_CheckExact(ob) Py_IS_TYPE(ob, &PyFrozenSet_Type)
+#define PyFrozenSet_Check(ob) \
+    (Py_IS_TYPE(ob, &PyFrozenSet_Type) || \
+      PyType_IsSubtype(Py_TYPE(ob), &PyFrozenSet_Type))
+
 #define PyAnySet_CheckExact(ob) \
     (Py_IS_TYPE(ob, &PySet_Type) || Py_IS_TYPE(ob, &PyFrozenSet_Type))
 #define PyAnySet_Check(ob) \
     (Py_IS_TYPE(ob, &PySet_Type) || Py_IS_TYPE(ob, &PyFrozenSet_Type) || \
       PyType_IsSubtype(Py_TYPE(ob), &PySet_Type) || \
       PyType_IsSubtype(Py_TYPE(ob), &PyFrozenSet_Type))
+
+#define PySet_CheckExact(op) Py_IS_TYPE(op, &PySet_Type)
 #define PySet_Check(ob) \
     (Py_IS_TYPE(ob, &PySet_Type) || \
     PyType_IsSubtype(Py_TYPE(ob), &PySet_Type))
-#define   PyFrozenSet_Check(ob) \
-    (Py_IS_TYPE(ob, &PyFrozenSet_Type) || \
-      PyType_IsSubtype(Py_TYPE(ob), &PyFrozenSet_Type))
 
 #ifdef __cplusplus
 }

--- a/Misc/NEWS.d/next/Core and Builtins/2021-02-20-16-50-22.bpo-43277.FXkRXk.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-02-20-16-50-22.bpo-43277.FXkRXk.rst
@@ -1,0 +1,3 @@
+Add a new :c:func:`PySet_CheckExact` function to the C-API to check if an
+object is an instance of :class:`set` but not an instance of a subtype.
+Patch by Pablo Galindo.

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -4482,7 +4482,7 @@ _PyDictView_Intersect(PyObject* self, PyObject *other)
 
     /* if other is a set and self is smaller than other,
        reuse set intersection logic */
-    if (Py_IS_TYPE(other, &PySet_Type) && len_self <= PyObject_Size(other)) {
+    if (PySet_CheckExact(other) && len_self <= PyObject_Size(other)) {
         _Py_IDENTIFIER(intersection);
         return _PyObject_CallMethodIdObjArgs(other, &PyId_intersection, self, NULL);
     }

--- a/Objects/setobject.c
+++ b/Objects/setobject.c
@@ -522,7 +522,7 @@ set_repr(PySetObject *so)
         goto done;
     listrepr = tmp;
 
-    if (!Py_IS_TYPE(so, &PySet_Type))
+    if (!PySet_CheckExact(so))
         result = PyUnicode_FromFormat("%s({%U})",
                                       Py_TYPE(so)->tp_name,
                                       listrepr);


### PR DESCRIPTION
For some mysterious reason we have PySet_Check, PyFrozenSet_Check, PyAnySet_Check, PyAnySet_CheckExact and PyFrozenSet_CheckExact but no PySet_CheckExact.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
