### PR TITLE
bpo-43319: Fixed the tutorial on venv about standard library (GH-24740)

### DIFF
--- a/Doc/tutorial/venv.rst
+++ b/Doc/tutorial/venv.rst
@@ -48,7 +48,7 @@ place it, and run the :mod:`venv` module as a script with the directory path::
 
 This will create the ``tutorial-env`` directory if it doesn't exist,
 and also create directories inside it containing a copy of the Python
-interpreter, the standard library, and various supporting files.
+interpreter and various supporting files.
 
 A common directory location for a virtual environment is ``.venv``.
 This name keeps the directory typically hidden in your shell and thus


### PR DESCRIPTION
In the [official tutorial on virtual environment](https://docs.python.org/3/tutorial/venv.html#creating-virtual-environments)

> This will create the tutorial-env directory if it doesn’t exist, and also create directories inside it containing a copy of the Python interpreter, **the standard library**, and various supporting files.

According to the actual behavior of `venv` and [PEP 405](https://www.python.org/dev/peps/pep-0405/#id15)'s description about virtual environment, no standard library file is included in the virtual environment's directory.

Automerge-Triggered-By: GH:vsajip

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
