### PR TITLE
bpo-43423 Fix IndexError in subprocess _communicate function (GH-24777)

### DIFF
--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -1535,10 +1535,8 @@ class Popen(object):
                 self.stderr.close()
 
             # All data exchanged.  Translate lists into strings.
-            if stdout is not None:
-                stdout = stdout[0]
-            if stderr is not None:
-                stderr = stderr[0]
+            stdout = stdout[0] if stdout else None
+            stderr = stderr[0] if stderr else None
 
             return (stdout, stderr)
 

--- a/Misc/NEWS.d/next/Library/2021-03-11-15-44-18.bpo-43423.rRomRD.rst
+++ b/Misc/NEWS.d/next/Library/2021-03-11-15-44-18.bpo-43423.rRomRD.rst
@@ -1,0 +1,2 @@
+:func:`subprocess.communicate` no longer raises an IndexError when there is an
+empty stdout or stderr IO buffer during a timeout on Windows.


### PR DESCRIPTION
Check to make sure stdout and stderr are not empty before selecting an item from them in Windows subprocess._communicate.

Co-authored-by: Gregory P. Smith <greg@krypto.org>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
