### PR TITLE
bpo-43510: Fix emitting EncodingWarning from _io module. (GH-25146)

### DIFF
--- a/Modules/_io/_iomodule.c
+++ b/Modules/_io/_iomodule.c
@@ -532,8 +532,10 @@ _io_text_encoding_impl(PyObject *module, PyObject *encoding, int stacklevel)
     if (encoding == NULL || encoding == Py_None) {
         PyInterpreterState *interp = _PyInterpreterState_GET();
         if (_PyInterpreterState_GetConfig(interp)->warn_default_encoding) {
-            PyErr_WarnEx(PyExc_EncodingWarning,
-                         "'encoding' argument not specified", stacklevel);
+            if (PyErr_WarnEx(PyExc_EncodingWarning,
+                             "'encoding' argument not specified", stacklevel)) {
+                return NULL;
+            }
         }
         Py_INCREF(_PyIO_str_locale);
         return _PyIO_str_locale;

--- a/Modules/_io/textio.c
+++ b/Modules/_io/textio.c
@@ -1085,6 +1085,19 @@ _io_TextIOWrapper___init___impl(textio *self, PyObject *buffer,
     self->ok = 0;
     self->detached = 0;
 
+    if (encoding == NULL) {
+        PyInterpreterState *interp = _PyInterpreterState_GET();
+        if (_PyInterpreterState_GetConfig(interp)->warn_default_encoding) {
+            if (PyErr_WarnEx(PyExc_EncodingWarning,
+                             "'encoding' argument not specified", 1)) {
+                return -1;
+            }
+        }
+    }
+    else if (strcmp(encoding, "locale") == 0) {
+        encoding = NULL;
+    }
+
     if (errors == Py_None) {
         errors = _PyUnicode_FromId(&PyId_strict); /* borrowed */
         if (errors == NULL) {
@@ -1122,17 +1135,6 @@ _io_TextIOWrapper___init___impl(textio *self, PyObject *buffer,
     self->pending_bytes_count = 0;
     self->encodefunc = NULL;
     self->b2cratio = 0.0;
-
-    if (encoding == NULL) {
-        PyInterpreterState *interp = _PyInterpreterState_GET();
-        if (_PyInterpreterState_GetConfig(interp)->warn_default_encoding) {
-            PyErr_WarnEx(PyExc_EncodingWarning,
-                         "'encoding' argument not specified", 1);
-        }
-    }
-    else if (strcmp(encoding, "locale") == 0) {
-        encoding = NULL;
-    }
 
     if (encoding == NULL) {
         /* Try os.device_encoding(fileno) */


### PR DESCRIPTION
I forget to check PyErr_WarnEx() return value. But it will fail when -Werror is used.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
