### PR TITLE
bpo-44622: Set line number of END_ASYNC_FOR to match that of iterator…

### DIFF
--- a/Lib/test/test_compile.py
+++ b/Lib/test/test_compile.py
@@ -943,10 +943,20 @@ if 1:
         genexp_lines = [None, 1, 3, 1]
 
         genexp_code = return_genexp.__code__.co_consts[1]
-        code_lines = [None if line is None else line-return_genexp.__code__.co_firstlineno
+        code_lines = [ None if line is None else line-return_genexp.__code__.co_firstlineno
                       for (_, _, line) in genexp_code.co_lines() ]
         self.assertEqual(genexp_lines, code_lines)
 
+    def test_line_number_implicit_return_after_async_for(self):
+
+        async def test(aseq):
+            async for i in aseq:
+                body
+
+        expected_lines = [None, 1, 2, 1]
+        code_lines = [ None if line is None else line-test.__code__.co_firstlineno
+                      for (_, _, line) in test.__code__.co_lines() ]
+        self.assertEqual(expected_lines, code_lines)
 
     def test_big_dict_literal(self):
         # The compiler has a flushing point in "compiler_dict" that calls compiles

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -3002,7 +3002,9 @@ compiler_async_for(struct compiler *c, stmt_ty s)
     /* Except block for __anext__ */
     compiler_use_next_block(c, except);
 
-    UNSET_LOC(c);
+    /* Use same line number as the iterator,
+     * as the END_ASYNC_FOR succeeds the `for`, not the body. */
+    SET_LOC(c, s->v.AsyncFor.iter);
     ADDOP(c, END_ASYNC_FOR);
 
     /* `else` block */


### PR DESCRIPTION
…. (GH-27160)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
