### PR TITLE
bpo-20291: Fix MSVC warnings in getargs.c (GH-27211)

### DIFF
--- a/Python/getargs.c
+++ b/Python/getargs.c
@@ -2552,7 +2552,8 @@ _PyArg_UnpackKeywordsWithVararg(PyObject *const *args, Py_ssize_t nargs,
     }
 
     /* copy keyword args using kwtuple to drive process */
-    for (i = Py_MAX((int)nargs, posonly) - varargssize; i < maxargs; i++) {
+    for (i = Py_MAX((int)nargs, posonly) -
+         Py_SAFE_DOWNCAST(varargssize, Py_ssize_t, int); i < maxargs; i++) {
         if (nkwargs) {
             keyword = PyTuple_GET_ITEM(kwtuple, i - posonly);
             if (kwargs != NULL) {


### PR DESCRIPTION
* Fix MSVC warnings in getargs.c

* apply suggestions

Co-Authored-By: Batuhan Taskaya <batuhan@python.org>

Co-authored-by: Batuhan Taskaya <batuhan@python.org>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
