### PR TITLE
bpo-44678: Separate error message for discontinuous padding in binasc…

### DIFF
--- a/Lib/test/test_binascii.py
+++ b/Lib/test/test_binascii.py
@@ -130,8 +130,11 @@ class BinASCIITest(unittest.TestCase):
         def assertNonBase64Data(data, non_strict_mode_expected_result: bytes):
             _assertRegexTemplate(r'(?i)Only base64 data', data, non_strict_mode_expected_result)
 
-        def assertMalformedPadding(data, non_strict_mode_expected_result: bytes):
+        def assertLeadingPadding(data, non_strict_mode_expected_result: bytes):
             _assertRegexTemplate(r'(?i)Leading padding', data, non_strict_mode_expected_result)
+
+        def assertDiscontinuousPadding(data, non_strict_mode_expected_result: bytes):
+            _assertRegexTemplate(r'(?i)Discontinuous padding', data, non_strict_mode_expected_result)
 
         # Test excess data exceptions
         assertExcessData(b'ab==a', b'i')
@@ -148,11 +151,11 @@ class BinASCIITest(unittest.TestCase):
         assertNonBase64Data(b'a\x00b==', b'i')
 
         # Test malformed padding
-        assertMalformedPadding(b'=', b'')
-        assertMalformedPadding(b'==', b'')
-        assertMalformedPadding(b'===', b'')
-        assertMalformedPadding(b'ab=c=', b'i\xb7')
-        assertMalformedPadding(b'ab=ab==', b'i\xb6\x9b')
+        assertLeadingPadding(b'=', b'')
+        assertLeadingPadding(b'==', b'')
+        assertLeadingPadding(b'===', b'')
+        assertDiscontinuousPadding(b'ab=c=', b'i\xb7')
+        assertDiscontinuousPadding(b'ab=ab==', b'i\xb6\x9b')
 
 
     def test_base64errors(self):

--- a/Misc/NEWS.d/next/Library/2021-07-19-18-45-00.bpo-44678.YMEAu0.rst
+++ b/Misc/NEWS.d/next/Library/2021-07-19-18-45-00.bpo-44678.YMEAu0.rst
@@ -1,0 +1,1 @@
+Added a separate error message for discontinuous padding in *binascii.a2b_base64* strict mode.

--- a/Modules/binascii.c
+++ b/Modules/binascii.c
@@ -464,7 +464,6 @@ binascii_a2b_base64_impl(PyObject *module, Py_buffer *data, int strict_mode)
     unsigned char *bin_data_start = bin_data;
 
     if (strict_mode && ascii_len > 0 && ascii_data[0] == '=') {
-        malformed_padding:
         state = get_binascii_state(module);
         if (state) {
             PyErr_SetString(state->Error, "Leading padding not allowed");
@@ -516,7 +515,11 @@ binascii_a2b_base64_impl(PyObject *module, Py_buffer *data, int strict_mode)
 
         // Characters that are not '=', in the middle of the padding, are not allowed
         if (strict_mode && padding_started) {
-            goto malformed_padding;
+            state = get_binascii_state(module);
+            if (state) {
+                PyErr_SetString(state->Error, "Discontinuous padding not allowed");
+            }
+            goto error_end;
         }
         pads = 0;
 


### PR DESCRIPTION
…ii.a2b_base64 strict mode (GH-27249)

* Renamed assertLeadingPadding function to match logic
* Added a separate error message for discontinuous padding
* Updated the tests for discontinuous padding

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
